### PR TITLE
Inline zip-folder dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,30 @@
 var fs = require('fs-extra');
 var path = require('path');
 var run = require('electron-installer-run');
-var zipFolder = require('zip-folder');
+var archiver = require('archiver');
 var series = require('async').series;
 var debug = require('debug')('electron-installer-zip');
+
+function zipFolder(srcFolder, zipFilePath, callback) {
+	var output = fs.createWriteStream(zipFilePath);
+	var zipArchive = archiver('zip');
+
+	output.on('close', function() {
+		callback();
+	});
+
+	zipArchive.pipe(output);
+
+	zipArchive.bulk([
+		{ cwd: srcFolder, src: ['**/*'], expand: true }
+	]);
+
+	zipArchive.finalize(function(err, bytes) {
+		if(err) {
+			callback(err);
+		}
+	});
+}
 
 module.exports = function(opts, done) {
   opts.dir = path.resolve(opts.dir);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var fs = require('fs-extra');
 var path = require('path');
 var run = require('electron-installer-run');
 var zipFolder = require('zip-folder');
-var format = require('util').format;
 var series = require('async').series;
 var debug = require('debug')('electron-installer-zip');
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "debug": "^2.2.0",
     "electron-installer-run": "^0.1.2",
     "fs-extra": "^1.0.0",
-    "mongodb-js-cli": "0.0.3",
-    "zip-folder": "^1.0.0"
+    "mongodb-js-cli": "0.0.3"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
As [zip-folder](https://www.npmjs.com/package/zip-folder) appears to be abandoned, this makes it clearer that we actually want to depend on an updated [archiver](https://www.npmjs.com/package/archiver) version, which I think may resolve an upstream [node-security issue](https://nodesecurity.io/orgs/mongodb-js/projects/f9e86f4b-3097-4b78-a027-ca9cf0184844/54#advisories).