### PR TITLE
chore: update organization URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ zip(opts, function(err, res) {
 
 Apache 2.0
 
-[travis_img]: https://img.shields.io/travis/mongodb-js/electron-installer-zip.svg
-[travis_url]: https://travis-ci.org/mongodb-js/electron-installer-zip
+[travis_img]: https://img.shields.io/travis/electron-userland/electron-installer-zip.svg
+[travis_url]: https://travis-ci.org/electron-userland/electron-installer-zip
 [npm_img]: https://img.shields.io/npm/v/electron-installer-zip.svg
 [npm_url]: https://npmjs.org/package/electron-installer-zip
 [electron-packager]: https://github.com/maxogden/electron-packager

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Create a zip file with support for symlinks required by electron on osx.",
   "version": "0.1.2",
   "author": "Lucas Hrabovsky <lucas@mongodb.com> (http://imlucas.com)",
-  "homepage": "http://github.com/mongodb-js/electron-installer-zip",
+  "homepage": "http://github.com/electron-userland/electron-installer-zip",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mongodb-js/electron-installer-zip.git"
+    "url": "git://github.com/electron-userland/electron-installer-zip.git"
   },
   "scripts": {
     "test": "npm run lint && npm run spec",


### PR DESCRIPTION
Small fix that updates the GitHub org associated with this repo to `electron-userland`. Will fix the build badge in the README.