### PR TITLE
Security fix: prevents env variable leak in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "archiver": "^1.2.0",
     "async": "^2.1.2",
     "debug": "^2.2.0",
-    "electron-installer-run": "^0.1.2",
+    "electron-installer-run": "^1.0.2",
     "fs-extra": "^1.0.0",
     "mongodb-js-cli": "0.0.3",
     "zip-folder": "^1.0.0"


### PR DESCRIPTION
electron-installer-run used to log env variables and other informations which would potentially leak secrets.